### PR TITLE
fix(ci): use PR number instead of branch name for Docker image tagging

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -95,7 +95,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=raw,value=pr-${{ github.head_ref || github.ref_name }}
+            type=raw,value=pr-${{ github.event.number }}
             type=sha
       - name: Build and Push Docker Image
         uses: docker/build-push-action@v5
@@ -111,5 +111,5 @@ jobs:
         run: |
           echo "✅ Docker image built and pushed!"
           echo "Tags: ${{ steps.meta.outputs.tags }}"
-          echo "PR tag: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ github.head_ref || github.ref_name }}"
+          echo "PR tag: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.number }}"
           echo "Commit hash tag: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}" 


### PR DESCRIPTION
## Problem

The PR CI workflow was tagging Docker images with the branch name (e.g., ) instead of the PR number (e.g., ).

## Solution

Changed the Docker metadata extraction to use  instead of .

## Changes

- **Before**:  → 
- **After**:  → 

## Benefits

- Consistent PR-based tagging for easier image identification
- Matches the retag workflow expectations
- Cleaner image tag names